### PR TITLE
Packetformat dissector

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,6 +19,7 @@ The packet definitions make use of same basic data types not directly defined by
 - **wstring**: Wide string of two byte, little endian UTF-16 characters, prefixed by its length in characters encoded as a two byte little endian integer, has no terminating null character.
 - **nativeparam**: An Otherland specific structured data type. (See: [Nativeparam format](doc/nativeparam.md))
 - **uuid**: A standard 128 bit, COM/OLE style, little endian Universally Unique Identifier.
+- **packet**: Another embedded packet, starting with its two byte identifier.
 
 The documents may also contain custom user defined data types and arrays of intrinsics or user defined types. These should be represented by appropriate data structures in the target language.
 

--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,7 @@ This repository documents the packet structure of the game "Otherland" in YAML f
 - **otherland.packet.schema.yaml**: Defines the structure of the packet definition documents in JSON Schema format.
 - **packets**: This folder contains the primary packet definition documents.
 - **structs**: Contains miscellaneous user defined structures used by the packet definitions.
+- **wireshark**: Dissectors for the Otherland RakNet transport protocol and application layer packets.
 
 ## Intrinsic Data Types
 
@@ -22,6 +23,20 @@ The packet definitions make use of same basic data types not directly defined by
 - **packet**: Another embedded packet, starting with its two byte identifier.
 
 The documents may also contain custom user defined data types and arrays of intrinsics or user defined types. These should be represented by appropriate data structures in the target language.
+
+## Wireshark Dissectors
+
+`otherland.lua` defines a dissector for the game's modified RakNet transport layer protocol. `packetformat_proto.lua` defines a dissector for the application layer packets described in the packet definition documents.
+
+To use the application layer dissector, you first need to process the packet definition documents with the [TreeHouse.PacketDocs](https://github.com/DRKV333/TreeHouse) tool.
+
+```
+TreeHouse.PacketDocs.exe lua -d . -o ./wireshark/packetformat_generated.lua
+```
+
+## Licensing
+
+The contents of this repository are provided under the CC0 license, except for the `wireshark` folder. These code files make use of Wireshark's API, so they are available under the GNU GPL.
 
 ## Contribute
 Please feel free to contribute by submitting PRs or raising issues. Ensure your additions or changes follow the established schema format.

--- a/README.MD
+++ b/README.MD
@@ -16,7 +16,7 @@ The packet definitions make use of same basic data types not directly defined by
 - **i8, i16, i32, i64**: Signed little endian integers of 8, 16, 32, and 64 bits respectively.
 - **f32, f64**: Single and double precision little endian IEEE 754 floating point numbers.
 - **cstring**: ANSI string of single byte characters, prefixed by its length in bytes encoded as a two byte little endian integer, has no terminating null character.
-- **wstring**: Wide string of two byte UTF-16 characters, prefixed by its length in bytes encoded as a two byte little endian integer, has no terminating null character.
+- **wstring**: Wide string of two byte, little endian UTF-16 characters, prefixed by its length in characters encoded as a two byte little endian integer, has no terminating null character.
 - **nativeparam**: An Otherland specific structured data type. (See: [Nativeparam format](doc/nativeparam.md))
 - **uuid**: A standard 128 bit, COM/OLE style, little endian Universally Unique Identifier.
 

--- a/otherland.packet.schema.yaml
+++ b/otherland.packet.schema.yaml
@@ -156,7 +156,7 @@ $defs:
         description: >
           This is an intrinsic type, not directly defined by the packet
           description document. See README for details.
-        enum: [bool, cstring, wstring, u8, u16, u32, u64, i8, i16, i32, i64, f32, f64, nativeparam, uuid]
+        enum: [bool, cstring, wstring, u8, u16, u32, u64, i8, i16, i32, i64, f32, f64, nativeparam, uuid, packet]
       - type: string
         description: >
           This is a user defined type that should appear in a 'structures'

--- a/packets/routing.yaml
+++ b/packets/routing.yaml
@@ -48,7 +48,7 @@ packets:
       - type: u8
       - type: u8
       - type: u64
-      - type: { name: array, len: _remainder, type: u8 }
+      - type: packet
   oaPktCheatingClusterNode:
     id: 0x8c
     subId: 0x35

--- a/wireshark/.gitignore
+++ b/wireshark/.gitignore
@@ -1,0 +1,1 @@
+packetformat_generated.lua

--- a/wireshark/otherland.lua
+++ b/wireshark/otherland.lua
@@ -241,7 +241,10 @@ function otherland_raknet.dissector(buffer, pinfo, tree)
         subtree:add(payload, payload_range)
         
         if packetformat_dissector ~= nil then
-            packetformat_dissector:call(payload_range:tvb(), pinfo, tree)
+            local message_id = payload_range:range(0, 1):bytes():get_index(0)
+            if message_id >= 100 then
+                packetformat_dissector:call(payload_range:tvb(), pinfo, tree)
+            end
         end
     end
 end

--- a/wireshark/otherland.lua
+++ b/wireshark/otherland.lua
@@ -139,6 +139,28 @@ function otherland_raknet.init()
     packetformat_dissector = Dissector.get("otherland.packetformat")
 end
 
+local internal_packets = {
+    1, -- ID_INTERNAL_PING
+    4, -- ID_CONNECTED_PONG
+    5, -- ID_CONNECTION_REQUEST
+    6, -- ID_SECURED_CONNECTION_RESPONSE
+    7, -- ID_SECURED_CONNECTION_CONFIRMATION
+    9, -- ID_OPEN_CONNECTION_REQUEST
+    10, --ID_OPEN_CONNECTION_REPLY
+    11, --ID_CONNECTION_REQUEST_ACCEPTED
+    14, --ID_NEW_INCOMING_CONNECTION
+    16, --ID_DISCONNECTION_NOTIFICATION
+}
+
+local function contains(table, value)
+    for k,v in ipairs(table) do
+        if v == value then
+            return true
+        end
+    end
+    return false
+end
+
 function otherland_raknet.dissector(buffer, pinfo, tree)
     print("Dissect")
 
@@ -242,7 +264,7 @@ function otherland_raknet.dissector(buffer, pinfo, tree)
         
         if packetformat_dissector ~= nil then
             local message_id = payload_range:range(0, 1):bytes():get_index(0)
-            if message_id >= 100 then
+            if not contains(internal_packets, message_id) then
                 packetformat_dissector:call(payload_range:tvb(), pinfo, tree)
             end
         end

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -63,7 +63,7 @@ local primitive_type_to_ftype = {
 }
 
 ---@param t any
----@return integer
+---@return integer,table?
 local function type_to_ftype(t)
     if type(t) == "number" then
         return ftypes.NONE
@@ -77,7 +77,7 @@ local function type_to_ftype(t)
                 return ftypes.NONE
             end
         else
-            return type_to_ftype(t.name)
+            return type_to_ftype(t.name), t.enum
         end
     end
 
@@ -87,7 +87,7 @@ end
 ---@type ProtoField[]
 local fields = {}
 for k, v in ipairs(format.fieldDefinitions) do
-    fields[k] = ProtoField.new(v.name, proto_name.."."..v.abbrev, type_to_ftype(v.type)) -- TODO: enums
+    fields[k] = ProtoField.new(v.name, proto_name.."."..v.abbrev, type_to_ftype(v.type))
 end
 
 ---@type ProtoField[]

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -62,6 +62,8 @@ local primitive_type_to_ftype = {
     nativeparam = ftypes.NONE -- TODO
 }
 
+---@param t any
+---@return integer
 local function type_to_ftype(t)
     if type(t) == "number" then
         return ftypes.NONE
@@ -74,6 +76,8 @@ local function type_to_ftype(t)
             return type_to_ftype(t.name)
         end
     end
+
+    return ftypes.NONE
 end
 
 ---@type ProtoField[]
@@ -88,6 +92,7 @@ for k, v in ipairs(format.packets) do
     packet_fields[k] = ProtoField.new(v.name, proto_name..".packet."..v.name, ftypes.NONE)
 end
 
+---@type ProtoField[]
 local struct_fields = {}
 for k, v in ipairs(format.structures) do
     struct_fields[k] = ProtoField.new(v.name, proto_name..".struct."..v.name, ftypes.NONE)
@@ -132,6 +137,8 @@ local primitive_len = {
     uuid = 16
 }
 
+---@param n number
+---@return number
 local function sign_byte(n)
     if bit32.btest(n, 128) then
       return -1 * (bit32.band(bit32.bnot(n), 255) + 1)

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -69,7 +69,7 @@ local function type_to_ftype(t)
         return primitive_type_to_ftype[t]
     elseif type(t) == "table" then
         if t.name == "array" then
-            return type_to_ftype(t.type)
+            return ftypes.NONE
         else
             return type_to_ftype(t.name)
         end
@@ -243,7 +243,7 @@ end
 ---@param tree TreeItem
 ---@param stash table
 ---@param field_ref number|table
----@return TvbRange
+---@return TvbRange,TreeItem
 local function dissect_field(tvb, tree, stash, field_ref)
     local field_index, field_len
     if type(field_ref) == "number" then
@@ -273,11 +273,11 @@ local function dissect_field(tvb, tree, stash, field_ref)
                 array_len = field_len
             end
 
-            local array_tree = tree:add(field_def.name, tvb)
+            tree = tree:add(proto_field, tvb)
 
             for i=1,array_len do
                 local item_tree
-                tvb, item_tree = dissect_simple(tvb, array_tree, proto_field, field_type.type, nil, nil)
+                tvb, item_tree = dissect_field(tvb, tree, stash, field_type.items)
                 item_tree:prepend_text("["..(i - 1).."] ")
             end
         else
@@ -287,7 +287,7 @@ local function dissect_field(tvb, tree, stash, field_ref)
         tvb, tree = dissect_simple(tvb, tree, proto_field, field_type, field_len, field_stash)
     end
 
-    return tvb
+    return tvb, tree
 end
 
 ---@param tvb TvbRange

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -315,6 +315,7 @@ local function dissect_field(tvb, tree, stash, field_ref)
     if type(field_type) == "table" then
         if field_type.name == "array" then
             local array_len
+            ---@cast field_len -nil
             if field_len < 0 then
                 array_len = stash[field_len * -1]
             else
@@ -327,14 +328,14 @@ local function dissect_field(tvb, tree, stash, field_ref)
                 tvb = tvb_safe_offset(tvb, array_len)
             else
                 tree = tree:add(proto_field, tvb)
-                
+
                 local new_tvb = tvb
                 for i=1,array_len do
                     local item_tree
                     new_tvb, item_tree = dissect_field(new_tvb, tree, stash, field_type.items)
                     item_tree:prepend_text("["..(i - 1).."] ")
                 end
-                
+
                 tree:set_len(new_tvb:offset() - tvb:offset())
                 tvb = new_tvb
             end

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -1,4 +1,4 @@
--- packet_format.lua - A template for dissectors generated from packet format definitions.
+-- packetformat.lua - A dissectors for packet format definitions.
 -- Copyright (C) 2024 Vince Kálmán
 -- 
 -- This program is free software: you can redistribute it and/or modify

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -88,6 +88,11 @@ for k, v in ipairs(format.packets) do
     packet_fields[k] = ProtoField.new(v.name, proto_name..".packet."..v.name, ftypes.NONE)
 end
 
+local struct_fields = {}
+for k, v in ipairs(format.structures) do
+    struct_fields[k] = ProtoField.new(v.name, proto_name..".struct."..v.name, ftypes.NONE)
+end
+
 ---@param to table
 ---@param what table
 local function add_range(to, what)
@@ -101,6 +106,7 @@ end
 local all_fields = {}
 add_range(all_fields, fields)
 add_range(all_fields, packet_fields)
+add_range(all_fields, struct_fields)
 proto.fields = all_fields
 
 ---@param tvb Tvb|TvbRange
@@ -230,9 +236,8 @@ local function dissect_simple(tvb, tree, proto_field, field_type, field_len, sta
             return dissect_with_lenght(tvb, tree, proto_field, field_type, stash)
         end
     elseif type(field_type) == "number" then
-        local structure = format.structures[field_type]
-        local struct_tree = tree:add(structure.name, tvb)
-        tvb = dissect_fields_list(tvb, struct_tree, structure)
+        local struct_tree = tree:add(struct_fields[field_type], tvb)
+        tvb = dissect_fields_list(tvb, struct_tree, format.structures[field_type])
         return tvb, struct_tree
     end
 

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -454,7 +454,7 @@ function proto.dissector(tvb, pinfo, tree)
         tvb = dissect_packet(tvb:range(2), proto_tree, pinfo.cols["info"], by_id_sub)
 
         if tvb:len() > 0 then
-            tree:add_proto_expert_info(expert_not_end_of_packet)
+            proto_tree:add_proto_expert_info(expert_not_end_of_packet)
         end
     end)
 

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -380,6 +380,7 @@ function PacketFormat:dissect_field(tvb, tree, info, stash, field_ref)
                     item_tree:prepend_text("["..(i - 1).."] ")
                 end
 
+                tree:append_text(" -> ["..array_len.."]")
                 tree:set_len(tvb:length_to(new_tvb))
                 tvb = new_tvb
             end
@@ -425,6 +426,7 @@ function PacketFormat:dissect_branch(tvb, tree, info, stash, branch)
         end
     end
 
+    tree:append_text(" -> ["..tostring(condition).."]")
     tree:set_len(tvb:length_to(tvb_new))
 
     return tvb_new

--- a/wireshark/packetformat.lua
+++ b/wireshark/packetformat.lua
@@ -1,0 +1,352 @@
+-- packet_format.lua - A template for dissectors generated from packet format definitions.
+-- Copyright (C) 2024 Vince Kálmán
+-- 
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+-- 
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local proto_name = "otherland.packetformat"
+
+local format_ok, format = pcall(require, "packetformat_generated")
+if not format_ok then
+    error("Generated definitions are not available, plase create them with the PacketDocs tool first.")
+end
+
+local proto = Proto.new(proto_name, "Otherland Packet Format")
+
+local expert_end_of_packet = ProtoExpert.new(
+    proto_name..".exp.endofpacket", "The end of the packet was reached, but more data was expected.",
+    expert.group.MALFORMED, expert.severity.ERROR
+)
+
+local expert_bad_id = ProtoExpert.new(
+    proto_name..".exp.badid", "Unknown packet id.",
+    expert.group.MALFORMED, expert.severity.ERROR
+)
+
+local expert_string_too_long = ProtoExpert.new(
+    proto_name..".exp.stringtoolong", "The lenght of this string is longer than the expected maximum.",
+    expert.group.PROTOCOL, expert.severity.WARN
+)
+
+proto.experts = {
+    expert_end_of_packet,
+    expert_bad_id,
+    expert_string_too_long
+}
+
+local primitive_type_to_ftype = {
+    bool = ftypes.BOOLEAN,
+    cstring = ftypes.STRING,
+    wstring = ftypes.STRING,
+    u8 = ftypes.UINT8,
+    u16 = ftypes.UINT16,
+    u32 = ftypes.UINT32,
+    u64 = ftypes.UINT64,
+    i8 = ftypes.INT8,
+    i16 = ftypes.INT16,
+    i32 = ftypes.INT32,
+    i64 = ftypes.INT64,
+    f32 = ftypes.FLOAT,
+    f64 = ftypes.DOUBLE,
+    uuid = ftypes.GUID,
+    nativeparam = ftypes.NONE -- TODO
+}
+
+local function type_to_ftype(t)
+    if type(t) == "number" then
+        return ftypes.NONE
+    elseif type(t) == "string" then
+        return primitive_type_to_ftype[t]
+    elseif type(t) == "table" then
+        if t.name == "array" then
+            return type_to_ftype(t.type)
+        else
+            return type_to_ftype(t.name)
+        end
+    end
+end
+
+---@type ProtoField[]
+local fields = {}
+for k, v in ipairs(format.fieldDefinitions) do
+    fields[k] = ProtoField.new(v.name, proto_name.."."..v.abbrev, type_to_ftype(v.type)) -- TODO: enums
+end
+
+---@type ProtoField[]
+local packet_fields = {}
+for k, v in ipairs(format.packets) do
+    packet_fields[k] = ProtoField.new(v.name, proto_name..".packet."..v.name, ftypes.NONE)
+end
+
+---@param to table
+---@param what table
+local function add_range(to, what)
+    local target_start = #to
+    for k, v in ipairs(what) do
+        to[k + target_start] = v
+    end
+end
+
+---@type ProtoField[]
+local all_fields = {}
+add_range(all_fields, fields)
+add_range(all_fields, packet_fields)
+proto.fields = all_fields
+
+---@param tvb Tvb|TvbRange
+---@param len number
+local function check_len(tvb, len)
+    if tvb:len() < len then
+        error({expert = expert_end_of_packet})
+    end
+end
+
+local primitive_len = {
+    bool = 1,
+    u8 = 1,
+    u16 = 2,
+    u32 = 4,
+    u64 = 8,
+    i8 = 1,
+    i16 = 2,
+    i32 = 4,
+    i64 = 8,
+    f32 = 4,
+    f64 = 8,
+    uuid = 16
+}
+
+local function sign_byte(n)
+    if bit32.btest(n, 128) then
+      return -1 * (bit32.band(bit32.bnot(n), 255) + 1)
+    else
+        return n
+    end
+end
+
+---@type { [string]: fun(tvb: TvbRange): number }
+local primitive_read = {
+    bool = function (tvb) return tvb:bytes():get_index(0) end,
+    u8 = function (tvb) return tvb:bytes():get_index(0) end,
+    u16 = function (tvb) return tvb:le_uint() end,
+    u32 = function (tvb) return tvb:le_uint() end,
+    u64 = function (tvb) return tvb:le_uint64() end,
+    i8 = function (tvb) return sign_byte(tvb:bytes():get_index(0)) end,
+    i16 = function (tvb) return tvb:le_int() end,
+    i32 = function (tvb) return tvb:le_int() end,
+    i64 = function (tvb) return tvb:le_int64() end,
+}
+
+---@param tvb TvbRange
+---@param tree TreeItem
+---@param field ProtoField
+---@param field_type string
+---@param stash? table
+---@return TvbRange, TreeItem
+local function dissect_with_lenght(tvb, tree, field, field_type, stash)
+    local len = primitive_len[field_type]
+
+    check_len(tvb, len)
+    local range = tvb:range(0, len)
+    local new_tree = tree:add_le(field, range)
+
+    if stash ~= nil then
+        stash[stash.put_here] = primitive_read[field_type](range)
+    end
+
+    return tvb:range(len), new_tree
+end
+
+---@param tvb TvbRange
+---@param tree TreeItem
+---@param field ProtoField
+---@param is_unicode boolean
+---@param maxlen? number
+---@param stash? table
+---@return TvbRange, TreeItem
+local function dissect_string(tvb, tree, field, is_unicode, maxlen, stash)
+    local enc
+    if is_unicode then
+        enc = ENC_UTF_16 + ENC_LITTLE_ENDIAN
+    else
+        enc = ENC_ASCII
+    end
+
+    check_len(tvb, 2)
+    local len = tvb:range(0, 2):le_uint()
+
+    if is_unicode then
+        len = len * 2
+    end
+
+    local value = ""
+    if len > 0 then 
+        check_len(tvb, 2 + len)
+        value = tvb:range(2, len):string(enc)
+    end
+
+    if stash ~= nil then
+        stash[stash.put_here] = value
+    end
+
+    local string_tree = tree:add(field, tvb:range(0, 2 + len), value)
+
+    if maxlen ~= nil and len > maxlen then
+        string_tree:add_proto_expert_info(expert_string_too_long)
+    end
+
+    return tvb:range(2 + len), string_tree
+end
+
+---@type fun(tvb: TvbRange, tree: TreeItem, fields_list: any): TvbRange
+local dissect_fields_list
+
+---@param tvb TvbRange
+---@param tree TreeItem
+---@param proto_field ProtoField
+---@param field_type any
+---@param field_len? number
+---@param stash? table
+---@return TvbRange, TreeItem
+local function dissect_simple(tvb, tree, proto_field, field_type, field_len, stash)
+    if type(field_type) == "string" then
+        if field_type == "cstring" then
+            return dissect_string(tvb, tree, proto_field, false, field_len, stash)
+        elseif field_type == "wstring" then
+            return dissect_string(tvb, tree, proto_field, true, field_len, stash)
+        elseif field_type == "nativeparam" then
+            return tvb, tree -- TODO
+        else
+            return dissect_with_lenght(tvb, tree, proto_field, field_type, stash)
+        end
+    elseif type(field_type) == "number" then
+        local structure = format.structures[field_type]
+        local struct_tree = tree:add(structure.name, tvb)
+        tvb = dissect_fields_list(tvb, struct_tree, structure)
+        return tvb, struct_tree
+    end
+
+    return tvb, tree
+end
+
+---@param tvb TvbRange
+---@param tree TreeItem
+---@param stash table
+---@param field_ref number|table
+---@return TvbRange
+local function dissect_field(tvb, tree, stash, field_ref)
+    local field_index, field_len
+    if type(field_ref) == "number" then
+        field_index = field_ref
+        field_len = nil
+    elseif type(field_ref) == "table" then
+        field_index = field_ref.index
+        field_len = field_ref.len
+    end
+
+    local field_def = format.fieldDefinitions[field_index]
+    local field_type = field_def.type
+    local proto_field = fields[field_index]
+
+    local field_stash = nil
+    if field_def.stash ~= nil then
+        stash.put_here = field_def.stash
+        field_stash = stash
+    end
+
+    if type(field_type) == "table" then
+        if field_type.name == "array" then
+            local array_len
+            if field_len < 0 then
+                array_len = stash[field_len * -1]
+            else
+                array_len = field_len
+            end
+
+            local array_tree = tree:add(field_def.name, tvb)
+
+            for i=1,array_len do
+                local item_tree
+                tvb, item_tree = dissect_simple(tvb, array_tree, proto_field, field_type.type, nil, nil)
+                item_tree:prepend_text("["..(i - 1).."] ")
+            end
+        else
+            tvb, tree = dissect_with_lenght(tvb, tree, proto_field, field_type.name, field_stash)
+        end
+    else
+        tvb, tree = dissect_simple(tvb, tree, proto_field, field_type, field_len, field_stash)
+    end
+
+    return tvb
+end
+
+---@param tvb TvbRange
+---@param tree TreeItem
+---@param fields_list any
+---@return TvbRange
+function dissect_fields_list(tvb, tree, fields_list)
+    local stash = {}
+
+    for k, v in ipairs(fields_list.fields) do
+        tvb = dissect_field(tvb, tree, stash, v)
+        -- TODO: branch
+    end
+
+    return tvb
+end
+
+---@param tvb TvbRange
+---@param tree TreeItem
+---@param packet_index number
+---@return TvbRange
+local function dissect_packet(tvb, tree, packet_index)
+    local packet = format.packets[packet_index]
+
+    local inherit = packet.inherit
+    if inherit ~= nil then
+        tvb = dissect_packet(tvb, tree, inherit)
+    end
+
+    local packet_tree = tree:add(packet_fields[packet_index], tvb)
+    return dissect_fields_list(tvb, packet_tree, packet)
+end
+
+function proto.dissector(tvb, pinfo, tree)
+    local proto_tree = tree:add(proto, tvb:range())
+
+    local success, message = pcall(function ()
+        check_len(tvb, 2)
+        local ids = tvb:bytes(0, 2)
+
+        local by_id_main = format.byId[ids:get_index(0)]
+        if by_id_main == nil then
+            error({expert = expert_bad_id})
+        end
+
+        local by_id_sub = by_id_main[ids:get_index(1)]
+        if by_id_sub == nil then
+            error({expert = expert_bad_id})
+        end
+
+        dissect_packet(tvb:range(2), proto_tree, by_id_sub)
+    end)
+
+    if not success then
+        if type(message) == "table" and message.expert ~= nil then
+            proto_tree:add_proto_expert_info(message.expert)
+        else
+            error(message)
+        end
+    end
+end
+

--- a/wireshark/packetformat_proto.lua
+++ b/wireshark/packetformat_proto.lua
@@ -21,7 +21,7 @@ local proto_name = "otherland.packetformat"
 
 local format_ok, format = pcall(require, "packetformat_generated")
 if not format_ok then
-    error("Generated definitions are not available, plase create them with the PacketDocs tool first.")
+    error("Generated definitions are not available, plase create them with the TreeHouse.PacketDocs tool first.")
 end
 
 local proto = Proto.new(proto_name, "Otherland Packet Format")

--- a/wireshark/packetformat_proto.lua
+++ b/wireshark/packetformat_proto.lua
@@ -1,0 +1,90 @@
+-- packetformat_proto.lua - Packet format protocol definition.
+-- Copyright (C) 2024 Vince Kálmán
+-- 
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+-- 
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local Vtvb = require("vtvb")
+local PacketFormat = require("packetformat")
+
+local proto_name = "otherland.packetformat"
+
+local format_ok, format = pcall(require, "packetformat_generated")
+if not format_ok then
+    error("Generated definitions are not available, plase create them with the PacketDocs tool first.")
+end
+
+local proto = Proto.new(proto_name, "Otherland Packet Format")
+
+local expert_end_of_packet = ProtoExpert.new(
+    ---@diagnostic disable-next-line
+    proto_name..".exp.endofpacket", Vtvb.errors.end_of_packet,
+    expert.group.MALFORMED, expert.severity.ERROR
+)
+Vtvb.errors.end_of_packet = {expert = expert_end_of_packet}
+
+local expert_not_end_of_packet = ProtoExpert.new(
+    proto_name.."exp.notendofpacket", "The packet was longer than expected, some data was not consumed.",
+    expert.group.UNDECODED, expert.severity.WARN
+)
+
+local expert_bad_id = ProtoExpert.new(
+    ---@diagnostic disable-next-line
+    proto_name..".exp.badid", PacketFormat.errors.bad_id,
+    expert.group.MALFORMED, expert.severity.ERROR
+)
+PacketFormat.errors.bad_id = {expert = expert_bad_id}
+
+local expert_string_too_long = ProtoExpert.new(
+    proto_name..".exp.stringtoolong", "The lenght of this string is longer than the expected maximum.",
+    expert.group.PROTOCOL, expert.severity.WARN
+)
+PacketFormat.experts.string_too_long = expert_string_too_long
+
+proto.experts = {
+    expert_end_of_packet,
+    expert_not_end_of_packet,
+    expert_bad_id,
+    expert_string_too_long
+}
+
+local packetformat_main = PacketFormat.new(format.main, proto_name)
+
+---@type ProtoField[]
+local all_fields = {}
+packetformat_main:add_all_fields(all_fields)
+proto.fields = all_fields
+
+function proto.dissector(tvb, pinfo, tree)
+    pinfo.cols["protocol"]:set("Packet Format")
+    pinfo.cols["info"]:clear()
+
+    local vtvb = Vtvb.new(tvb)
+    local proto_tree = tree:add(proto, tvb:range())
+
+    local success, message = pcall(function ()
+        vtvb = packetformat_main:dissect_discriminated(vtvb, proto_tree, pinfo.cols["info"])
+
+        if vtvb:len() > 0 then
+            proto_tree:add_proto_expert_info(expert_not_end_of_packet)
+        end
+    end)
+
+    if not success then
+        if type(message) == "table" and message.expert ~= nil then
+            proto_tree:add_proto_expert_info(message.expert)
+        else
+            error(message)
+        end
+    end
+end

--- a/wireshark/packetformat_proto.lua
+++ b/wireshark/packetformat_proto.lua
@@ -61,9 +61,9 @@ proto.experts = {
 local packetformat_main = PacketFormat.new(format.main, proto_name)
 local packetformat_nativeparam = PacketFormat.new(format.nativeparam, proto_name..".nativeparam")
 
-packetformat_main:add_custom_dissector("packet", packetformat_main:get_discriminated_dissector_func())
-packetformat_main:add_custom_dissector("nativeparam", packetformat_nativeparam:get_specific_dissector_func("struct"))
-packetformat_nativeparam:add_custom_dissector("nativeparam", packetformat_nativeparam:get_discriminated_dissector_func())
+packetformat_main:add_custom_dissector("packet", packetformat_main:get_discriminated_dissector_func(true))
+packetformat_main:add_custom_dissector("nativeparam", packetformat_nativeparam:get_specific_dissector_func("struct", false))
+packetformat_nativeparam:add_custom_dissector("nativeparam", packetformat_nativeparam:get_discriminated_dissector_func(true))
 
 ---@type ProtoField[]
 local all_fields = {}

--- a/wireshark/packetformat_proto.lua
+++ b/wireshark/packetformat_proto.lua
@@ -59,10 +59,16 @@ proto.experts = {
 }
 
 local packetformat_main = PacketFormat.new(format.main, proto_name)
+local packetformat_nativeparam = PacketFormat.new(format.nativeparam, proto_name..".nativeparam")
+
+packetformat_main:add_custom_dissector("packet", packetformat_main:get_discriminated_dissector_func())
+packetformat_main:add_custom_dissector("nativeparam", packetformat_nativeparam:get_specific_dissector_func("struct"))
+packetformat_nativeparam:add_custom_dissector("nativeparam", packetformat_nativeparam:get_discriminated_dissector_func())
 
 ---@type ProtoField[]
 local all_fields = {}
 packetformat_main:add_all_fields(all_fields)
+packetformat_nativeparam:add_all_fields(all_fields)
 proto.fields = all_fields
 
 function proto.dissector(tvb, pinfo, tree)

--- a/wireshark/vtvb.lua
+++ b/wireshark/vtvb.lua
@@ -94,7 +94,6 @@ function Vtvb:length_to(other)
     return other.my_offset - self.my_offset
 end
 
--- TODO: Disallow strings for proto_field here.
 ---@param tree TreeItem
 ---@param proto_field Proto|ProtoField 
 ---@param value? any

--- a/wireshark/vtvb.lua
+++ b/wireshark/vtvb.lua
@@ -96,7 +96,7 @@ end
 
 -- TODO: Disallow strings for proto_field here.
 ---@param tree TreeItem
----@param proto_field Proto|ProtoField|string 
+---@param proto_field Proto|ProtoField 
 ---@param value? any
 ---@return TreeItem
 function Vtvb:tree_add_le(tree, proto_field, value)

--- a/wireshark/vtvb.lua
+++ b/wireshark/vtvb.lua
@@ -1,0 +1,118 @@
+-- vtvb.lua - Virtual Testy Virtual Buffer
+-- Copyright (C) 2024 Vince Kálmán
+-- 
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+-- 
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+-- 
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+---@class Vtvb
+---@field private my_tvb Tvb
+---@field private my_offset number
+---@field private my_length number
+---@field private my_explicit boolean
+local Vtvb = {}
+Vtvb.__index = Vtvb
+Vtvb.errors = {
+    end_of_packet = "The end of the packet was reached, but more data was expected.",
+    end_of_range = "Tried to read outside of an explicitly sized range.",
+    zero_lenght = "Can't create 0 length TvbRange."
+}
+
+---@param tvb Tvb
+---@return Vtvb
+function Vtvb.new(tvb)
+    return setmetatable({
+        my_tvb = tvb,
+        my_offset = 0,
+        my_length = tvb:len(),
+        my_explicit = false
+    }, Vtvb)
+end
+
+---@return number
+function Vtvb:offset() return self.my_offset end
+
+---@return number
+function Vtvb:len() return self.my_length end
+
+---@return TvbRange
+function Vtvb:tvb()
+    if self.my_length == 0 then
+        error(Vtvb.errors.zero_lenght)
+    end
+    return self.my_tvb:range(self.my_offset, self.my_length)
+end
+
+---@param offset number
+---@param lenght? number
+---@return Vtvb
+function Vtvb:range(offset, lenght)
+    local explicit = true
+    if lenght == nil then
+        lenght = self.my_length - offset
+        explicit = false
+    end
+
+    if offset < 0 or lenght < 0 then
+        error(Vtvb.errors.end_of_range)
+    end
+
+    if offset > self.my_length or lenght > (self.my_length - offset) then
+        if self.my_explicit then
+            error(Vtvb.errors.end_of_range)
+        else
+            error(Vtvb.errors.end_of_packet)
+        end
+    end
+
+    return setmetatable({
+        my_tvb = self.my_tvb,
+        my_offset = self.my_offset + offset,
+        my_length = lenght,
+        my_explicit = explicit
+    }, Vtvb)
+end
+
+---@param length number
+---@return Vtvb
+function Vtvb:slice(length)
+    return self:range(0, length)
+end
+
+---@param other Vtvb
+---@return number
+function Vtvb:length_to(other)
+    return other.my_offset - self.my_offset
+end
+
+-- TODO: Disallow strings for proto_field here.
+---@param tree TreeItem
+---@param proto_field Proto|ProtoField|string 
+---@param value? any
+---@return TreeItem
+function Vtvb:tree_add_le(tree, proto_field, value)
+    if self.my_length ~= 0 then
+        if value == nil then
+            return tree:add_le(proto_field, self:tvb())
+        else
+            return tree:add_le(proto_field, self:tvb(), value)
+        end
+    else
+        if value == nil then
+            return tree:add_le(proto_field)
+        else
+            return tree:add_le(proto_field, value)
+        end
+    end
+end
+
+return Vtvb


### PR DESCRIPTION
This PR adds a Wireshark dissector for application layer packets.

To facilitate parsing of nested packets, a new intrinsic type `packet` was added, instead of the undocumented `_remainder` field usage in `routing.yam`. This is a breaking change.

The existing RakNet dissector was updated to process payloads with the new dissector. This is not entirely functional, I didn't add PDU reassembly, and it looks like there are some other issues as well. Still, it works as a proof-of-concept for the application layer dissector.

Using the new dissector requires some preprocessing of the packet definition, which I've also mentioned in the README.