### PR TITLE
Description fix

### DIFF
--- a/otherland.packet.schema.yaml
+++ b/otherland.packet.schema.yaml
@@ -53,11 +53,6 @@ $defs:
               the current packet, appearing before the field list
               defined here.
             type: string
-          description:
-            description: >
-              A description of the packets content and function. This is 
-              intended to be a human readable text for documentation purposes.
-            type: string
           relatesTo:
             description: >
               A list of packets this packet relates to. This is intended to 
@@ -76,13 +71,6 @@ $defs:
       A reusable user defined type.
     allOf:
       - { $ref: "#/$defs/fieldsList" }
-      - type: object
-        properties:
-          description:
-            description: >
-              A description of the structures content and function. This is 
-              intended to be a human readable text for documentation purposes.
-            type: string
 
   fieldsList:
     type: object
@@ -93,6 +81,11 @@ $defs:
           Fields are serialized sequentially with no padding.
         type: array
         items: { $ref: "#/$defs/fieldItem" }
+      description:
+        description: >
+          A description of the object's content and function. This is 
+          intended to be a human readable text for documentation purposes.
+        type: string
 
   fieldItem:
     anyOf:

--- a/otherland.packet.schema.yaml
+++ b/otherland.packet.schema.yaml
@@ -63,7 +63,8 @@ $defs:
               A list of packets this packet relates to. This is intended to 
               be used as an informative list of references to other packets.
             type: array
-            items: string
+            items:
+              type: string
 
   idByte:
     type: integer


### PR DESCRIPTION
A small issues was introduced by the new description schema change. The current definition for the `relatesTo` field on packets is invalid. `items` needs to be a valid schema, which can only be an object or boolean.

I've also moved the `description` field, which is common to both packets and structures into `fieldsList`. My original intention with `fieldsList` was to store common things like this.